### PR TITLE
Add code to disable compliant mode for head after a behavior

### DIFF
--- a/hello_world/behavior_player.py
+++ b/hello_world/behavior_player.py
@@ -93,6 +93,8 @@ Make sure that reachy_sdk_server.service is running and that you entered the cor
             reachy.turn_off_smoothly('l_arm')
         if not reachy.r_arm.r_shoulder_pitch.compliant:
             reachy.turn_off_smoothly('r_arm')
+        if not reachy.head.r_antenna.compliant:
+            reachy.turn_off_smoothly('head')
 
     except KeyboardInterrupt:
         print(f'Ctrl-C received, stopping the {requested_behavior} behavior...')


### PR DESCRIPTION
Fix issue where Reachy's head remains in compliant mode after executing a behavior.